### PR TITLE
route fix

### DIFF
--- a/components/Signin/signin.js
+++ b/components/Signin/signin.js
@@ -12,7 +12,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import {MyContext} from '../../script'
-
+import {useHistory} from "react-router-dom";
 
 
 const useStyles = makeStyles((theme) => ({
@@ -40,6 +40,7 @@ const context = useContext(MyContext)
 const classes = useStyles();
 let user, pwd;
 /// вместо changeHandler как в loginForm использовать useRef-хук для ссылок на поля с именем и паролем
+const history = useHistory();
 
 const Login = async (login, password) => {
  
@@ -60,7 +61,8 @@ const Login = async (login, password) => {
           "https://dishingouthealth.com/wp-content/uploads/2020/02/VegPaella-500x500.jpg",
           "https://i.pinimg.com/564x/25/9f/04/259f049e11b0def18663d8646a0ac3c0.jpg"
           ]}) ;
-props.setLogged(true)
+props.setLogged(true);
+history.push("/privateContent");
 
   }
 

--- a/script.js
+++ b/script.js
@@ -85,7 +85,7 @@ const App = () => {
         <br/>
 
         
-        <li> <a style={{textDecoration: "underline"}} onClick={()=>{isLogged? setLogged(false) : none}} >Public only (Logout)</a></li>
+        <li> <a style={{textDecoration: "underline"}} onClick={()=> setLogged(false)} >Public only (Logout)</a></li>
         
 </ul>
 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // import LoginForm from './components/LoginForm/loginForm';
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import ReactDom from 'react-dom';
 import Gallery from './components/Gallery/gallery'
 import SignIn from './components/Signin/signin'
@@ -34,13 +34,15 @@ return (
 }
 
 const PrivateContent = (props)=> {
-        let show = false
         
-        const content = show? props.children : null
+        
+        const content = props.isLogged ? props.children : <Redirect to="/loginSection"></Redirect>
+
+
         return (
                 <>
                 
-                {show? content : null}
+                {content}
                
                 </>
         )
@@ -61,10 +63,11 @@ const App = () => {
         
  
   const [isLogged, setLogged] = useState(false)
-  const [showPrivate, setShow] = useState(false)
 
+  useEffect(()=> {
+          console.log("isLogged"+isLogged)
+  }, [isLogged])
 
-//   const content = isLogged? <Gallery/> :<SignIn setLogged={setLogged}/> 
 
 
 
@@ -76,16 +79,14 @@ const App = () => {
 
 <ul style={{listStyleType: "none",fontSize: "15px", position: "absolute", left: "5px", top: "5px"}}>
         <Link to="/privateContent">        
-        <li style={{textDecoration: "underline"}} onClick={()=> isLogged ? setShow(showPrivate) : setShow(showPrivate)}>Show/Hide Private content</li>
+        <li style={{textDecoration: "underline"}} >Show Private content</li>
         </Link>
 
         <br/>
 
         
-
-        <Link to="/loginSection">
-        <li style={{textDecoration: "underline"}} onClick={()=>{isLogged? setLogged(false) : none}}>Public only (LogOut)</li>
-        </Link>
+        <li> <a style={{textDecoration: "underline"}} onClick={()=>{isLogged? setLogged(false) : none}} >Public only (Logout)</a></li>
+        
 </ul>
 
 
@@ -98,22 +99,16 @@ const App = () => {
 
 
 <Switch>
-<Route path="/">
-<Redirect to="/loginSection"></Redirect>
-</Route>
 
-        <Route path="/privateContent">
-<PrivateContent>
+<Route path="/privateContent">
+<PrivateContent isLogged={isLogged}>
 <Gallery/>
 </PrivateContent>
-        </Route>
+</Route>
         
         <Route path="/loginSection">
-        <>
-        <p>sdfdsf</p>
-        <SignIn setLogged={setLogged}/>
-        </>
-        </Route>
+               <SignIn setLogged={setLogged}/>
+         </Route>
 </Switch>
 
 


### PR DESCRIPTION
- был конфликт роутов. Например путь /privateContent всегда редиректился на loginSection, потому что "/" тоже к нему относился. Решается аттрибутом exact "/" . Но я вообще этот редирект с главной убрал, логин с кнопки теперь.

и по мелочи правки про то как логичнее попадать к "/privatecontent":
-  лишняя инфа в состоянии типа showPrivate, с роутами уже не нужна. Вместо нее HOC(Higher Order Component)-компонент  PrivateContent, через свои пропсы сам решает показывать props.children или нет.  

Добавил два новых хука:
- useHistory чтобы менять URL в браузере без ссылок и редиректов. Используется чтобы перейти в "/privateContent" когда пользователь авторизовался.)

- (здесь не обязателен - просто демо) useEffect чтобы подписаться на изменение любых данных. Например здесь выводим в консоль любые обновления isLogged . Хук часто используется для связи компонентов, реакции одного на другой

